### PR TITLE
feat: add platform selection for cm3588

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 amur-rpi-builder
 ===
 
-Docker image for building libraries for Raspberry Pi4 target.
+Docker image for building libraries for embedded targets.
+Supported platforms:
+
+- Raspberry Pi 4
+- CM3588 Plus (requires `meta-rockchip` layer)
 
 ## Prerequisites
 Docker
@@ -10,5 +14,17 @@ Docker
 ```
 git clone --recurse-submodules https://github.com/ARDev1161/amur-rpi4-builder.git
 cd amur-rpi4-builder
-./build.sh
+```
+
+To build for Raspberry Pi 4 (default):
+
+```
+./build.sh --platform rpi4
+```
+
+To build for CM3588 Plus, ensure the `meta-rockchip` layer is available at
+`meta-rockchip` and then run:
+
+```
+./build.sh --platform cm3588-plus
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 docker build -t yocto-builder .
-docker run -it  --rm --name yocto-builder-container --mount type=bind,src="$(pwd)",target=/home/build yocto-builder bash -c "./yocto-build.sh"
+docker run -it --rm --name yocto-builder-container \
+    --mount type=bind,src="$(pwd)",target=/home/build \
+    yocto-builder bash -c "./yocto-build.sh \"$@\"" -- "$@"


### PR DESCRIPTION
## Summary
- allow choosing target platform with new `--platform` option
- update build script to forward arguments into container
- document Raspberry Pi 4 and CM3588 Plus build instructions

## Testing
- `bash -n yocto-build.sh`
- `bash -n build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5976aa894833280a36482689e299a